### PR TITLE
feat: convert from CommonJS to ESModule format

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,15 @@
   "name": "@fyuuki0jp/railway-result",
   "version": "0.1.0",
   "description": "TypeScript Result type implementation for Railway Oriented Programming",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/src/__tests__/do-notation.test.ts
+++ b/src/__tests__/do-notation.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ok, err, isOk, isErr, Do, type Result } from '../index';
+import { ok, err, isOk, isErr, Do, type Result } from '../index.js';
 
 describe('Do記法とResultChain', () => {
   describe('Do関数 - 初期化', () => {

--- a/src/__tests__/examples.test.ts
+++ b/src/__tests__/examples.test.ts
@@ -15,7 +15,7 @@ import {
   isErr,
   Do,
   type Result
-} from '../index';
+} from '../index.js';
 
 describe('実用的な使用例', () => {
   describe('ユーザー登録システム', () => {

--- a/src/__tests__/guards.test.ts
+++ b/src/__tests__/guards.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ok, err, isOk, isErr, type Result } from '../index';
+import { ok, err, isOk, isErr, type Result } from '../index.js';
 
 describe('型ガード関数', () => {
   describe('isOk関数 - 成功結果の判定', () => {

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -19,7 +19,7 @@ import {
   mapAsyncPromiseResult,
   zodToResult,
   type Result 
-} from '../index';
+} from '../index.js';
 
 describe('統合テスト', () => {
   describe('複合的なデータ処理パイプライン', () => {

--- a/src/__tests__/result.test.ts
+++ b/src/__tests__/result.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ok, err, isOk, isErr, type Result } from '../index';
+import { ok, err, isOk, isErr, type Result } from '../index.js';
 
 describe('Result基本機能', () => {
   describe('ok関数 - 成功結果の作成', () => {

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -16,7 +16,7 @@ import {
   mapPromiseResult, 
   mapAsyncPromiseResult,
   type Result 
-} from '../index';
+} from '../index.js';
 
 describe('ユーティリティ関数', () => {
   describe('fromPromise関数 - PromiseからResultへの変換', () => {

--- a/src/__tests__/zod-helpers.test.ts
+++ b/src/__tests__/zod-helpers.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { zodToResult, isOk, isErr } from '../index';
+import { zodToResult, isOk, isErr } from '../index.js';
 
 describe('Zod統合ヘルパー', () => {
   describe('zodToResult関数 - Zod結果のResult型変換', () => {

--- a/src/do-notation.ts
+++ b/src/do-notation.ts
@@ -2,9 +2,9 @@
  * Do notation implementation for Result types
  */
 
-import type { Result } from './types';
-import { ok, err } from './result';
-import { isOk } from './guards';
+import type { Result } from './types.js';
+import { ok, err } from './result.js';
+import { isOk } from './guards.js';
 
 /**
  * Result型のDo記法風の実装

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -2,7 +2,7 @@
  * Type guard functions for Result types
  */
 
-import type { Result, Success, Failure } from './types';
+import type { Result, Success, Failure } from './types.js';
 
 /**
  * Type guard to check if a Result is a Success

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,22 +6,22 @@
  */
 
 // Core Result types
-export type { Result } from './types';
-export type { Success, Failure } from './types';
+export type { Result } from './types.js';
+export type { Success, Failure } from './types.js';
 
 // Result creation functions
-export { ok, err } from './result';
+export { ok, err } from './result.js';
 
 // Type guards
-export { isOk, isErr } from './guards';
+export { isOk, isErr } from './guards.js';
 
 // Utility functions
-export { fromPromise, toPromise } from './utils';
-export { mapPromiseResult, mapAsyncPromiseResult } from './utils';
+export { fromPromise, toPromise } from './utils.js';
+export { mapPromiseResult, mapAsyncPromiseResult } from './utils.js';
 
 // Do notation and chaining
-export { Do } from './do-notation';
-export { ResultChain } from './do-notation';
+export { Do } from './do-notation.js';
+export { ResultChain } from './do-notation.js';
 
 // Zod integration helpers
-export { zodToResult } from './zod-helpers';
+export { zodToResult } from './zod-helpers.js';

--- a/src/result.ts
+++ b/src/result.ts
@@ -2,7 +2,7 @@
  * Result creation functions and implementations
  */
 
-import type { Result, Success, Failure } from './types';
+import type { Result, Success, Failure } from './types.js';
 
 /**
  * Creates a success result with chainable methods

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,9 +2,9 @@
  * Utility functions for working with Result types
  */
 
-import type { Result } from './types';
-import { ok, err } from './result';
-import { isOk } from './guards';
+import type { Result } from './types.js';
+import { ok, err } from './result.js';
+import { isOk } from './guards.js';
 
 /**
  * Converts a Promise<T> to Promise<Result<T, E>>

--- a/src/zod-helpers.ts
+++ b/src/zod-helpers.ts
@@ -2,8 +2,8 @@
  * Helper functions for integrating with Zod validation library
  */
 
-import type { Result } from './types';
-import { ok, err } from './result';
+import type { Result } from './types.js';
+import { ok, err } from './result.js';
 
 /**
  * Helper function to convert Zod SafeParseReturnType to Result

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "ES2022",
     "lib": ["ES2020"],
     "declaration": true,
     "outDir": "./dist",
@@ -10,7 +10,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true
   },


### PR DESCRIPTION
- Add \type\: \module\ to package.json
- Update tsconfig.json to use ES2022 module system
- Add .js extensions to all relative imports
- Update test files to use ESModule imports

🤖 Generated with [Claude Code](https://claude.ai/code)