### PR TITLE
Prepare package for npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: PR Check
+name: Publish to npm
 
 on:
   push:
@@ -11,6 +11,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Node.js
         uses: actions/setup-node@v3
+        with:
+          node-version: 'latest'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm install
       - name: Run tests
@@ -20,4 +23,4 @@ jobs:
       - name: Publish Package
         run: npm publish
         env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,43 @@
+# Source files
+src/
+*.ts
+!dist/**/*.d.ts
+
+# Test files
+__tests__/
+*.test.*
+*.spec.*
+vitest.config.*
+
+# Development files
+.claude/
+.github/
+.git/
+.gitignore
+.npmrc
+
+# Build files
+tsconfig.json
+node_modules/
+package-lock.json
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Coverage
+coverage/
+.nyc_output/

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
-@fyuuki0jp:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fyuuki0jp/railway-result",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "TypeScript Result type implementation for Railway Oriented Programming",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "url": "https://github.com/fyuuki0jp/railway-result/issues"
   },
   "homepage": "https://github.com/fyuuki0jp/railway-result#readme",
-  "access": "public"
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fyuuki0jp/railway-result",
+  "name": "railway-result",
   "version": "0.2.0",
   "description": "TypeScript Result type implementation for Railway Oriented Programming",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,15 @@
   "name": "@fyuuki0jp/railway-result",
   "version": "0.1.0",
   "description": "TypeScript Result type implementation for Railway Oriented Programming",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/src/__tests__/do-notation.test.ts
+++ b/src/__tests__/do-notation.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ok, err, isOk, isErr, Do, type Result } from '../index';
+import { ok, err, isOk, isErr, Do, type Result } from '../index.js';
 
 describe('Do記法とResultChain', () => {
   describe('Do関数 - 初期化', () => {

--- a/src/__tests__/examples.test.ts
+++ b/src/__tests__/examples.test.ts
@@ -15,7 +15,7 @@ import {
   isErr,
   Do,
   type Result
-} from '../index';
+} from '../index.js';
 
 describe('実用的な使用例', () => {
   describe('ユーザー登録システム', () => {

--- a/src/__tests__/guards.test.ts
+++ b/src/__tests__/guards.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ok, err, isOk, isErr, type Result } from '../index';
+import { ok, err, isOk, isErr, type Result } from '../index.js';
 
 describe('型ガード関数', () => {
   describe('isOk関数 - 成功結果の判定', () => {

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -19,7 +19,7 @@ import {
   mapAsyncPromiseResult,
   zodToResult,
   type Result 
-} from '../index';
+} from '../index.js';
 
 describe('統合テスト', () => {
   describe('複合的なデータ処理パイプライン', () => {

--- a/src/__tests__/result.test.ts
+++ b/src/__tests__/result.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ok, err, isOk, isErr, type Result } from '../index';
+import { ok, err, isOk, isErr, type Result } from '../index.js';
 
 describe('Result基本機能', () => {
   describe('ok関数 - 成功結果の作成', () => {

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -16,7 +16,7 @@ import {
   mapPromiseResult, 
   mapAsyncPromiseResult,
   type Result 
-} from '../index';
+} from '../index.js';
 
 describe('ユーティリティ関数', () => {
   describe('fromPromise関数 - PromiseからResultへの変換', () => {

--- a/src/__tests__/zod-helpers.test.ts
+++ b/src/__tests__/zod-helpers.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { zodToResult, isOk, isErr } from '../index';
+import { zodToResult, isOk, isErr } from '../index.js';
 
 describe('Zod統合ヘルパー', () => {
   describe('zodToResult関数 - Zod結果のResult型変換', () => {

--- a/src/do-notation.ts
+++ b/src/do-notation.ts
@@ -2,9 +2,9 @@
  * Do notation implementation for Result types
  */
 
-import type { Result } from './types';
-import { ok, err } from './result';
-import { isOk } from './guards';
+import type { Result } from './types.js';
+import { ok, err } from './result.js';
+import { isOk } from './guards.js';
 
 /**
  * Result型のDo記法風の実装

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -2,7 +2,7 @@
  * Type guard functions for Result types
  */
 
-import type { Result, Success, Failure } from './types';
+import type { Result, Success, Failure } from './types.js';
 
 /**
  * Type guard to check if a Result is a Success

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,22 +6,22 @@
  */
 
 // Core Result types
-export type { Result } from './types';
-export type { Success, Failure } from './types';
+export type { Result } from './types.js';
+export type { Success, Failure } from './types.js';
 
 // Result creation functions
-export { ok, err } from './result';
+export { ok, err } from './result.js';
 
 // Type guards
-export { isOk, isErr } from './guards';
+export { isOk, isErr } from './guards.js';
 
 // Utility functions
-export { fromPromise, toPromise } from './utils';
-export { mapPromiseResult, mapAsyncPromiseResult } from './utils';
+export { fromPromise, toPromise } from './utils.js';
+export { mapPromiseResult, mapAsyncPromiseResult } from './utils.js';
 
 // Do notation and chaining
-export { Do } from './do-notation';
-export { ResultChain } from './do-notation';
+export { Do } from './do-notation.js';
+export { ResultChain } from './do-notation.js';
 
 // Zod integration helpers
-export { zodToResult } from './zod-helpers';
+export { zodToResult } from './zod-helpers.js';

--- a/src/result.ts
+++ b/src/result.ts
@@ -2,7 +2,7 @@
  * Result creation functions and implementations
  */
 
-import type { Result, Success, Failure } from './types';
+import type { Result, Success, Failure } from './types.js';
 
 /**
  * Creates a success result with chainable methods

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,9 +2,9 @@
  * Utility functions for working with Result types
  */
 
-import type { Result } from './types';
-import { ok, err } from './result';
-import { isOk } from './guards';
+import type { Result } from './types.js';
+import { ok, err } from './result.js';
+import { isOk } from './guards.js';
 
 /**
  * Converts a Promise<T> to Promise<Result<T, E>>

--- a/src/zod-helpers.ts
+++ b/src/zod-helpers.ts
@@ -2,8 +2,8 @@
  * Helper functions for integrating with Zod validation library
  */
 
-import type { Result } from './types';
-import { ok, err } from './result';
+import type { Result } from './types.js';
+import { ok, err } from './result.js';
 
 /**
  * Helper function to convert Zod SafeParseReturnType to Result

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "ES2022",
     "lib": ["ES2020"],
     "declaration": true,
     "outDir": "./dist",
@@ -10,7 +10,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true
   },


### PR DESCRIPTION
## Summary
- Create .npmignore to exclude development files from npm package
- Remove personal account prefix from package name for public npm registry
- Update GitHub Actions workflow to use latest Node.js version and npm registry
- Remove .npmrc file that was configured for GitHub Package Registry

## Changes
- Added `.npmignore` to exclude unnecessary files (.claude/, .github/, tests, etc.)
- Changed package name from `@fyuuki0jp/railway-result` to `railway-result`
- Updated GitHub Actions to use Node.js `latest` and proper npm registry configuration
- Removed `.npmrc` file for public npm publishing

## Test plan
- [x] Verify package.json is valid JSON
- [x] Confirm build process works (`npm run build`)
- [x] Check that dist files are generated correctly
- [ ] Run `npm publish --dry-run` to verify publishing configuration
- [ ] Verify GitHub Actions will use correct npm token (requires NPM_TOKEN secret)

🤖 Generated with [Claude Code](https://claude.ai/code)